### PR TITLE
fix: set slb token for meta data and update

### DIFF
--- a/src/libs/installer/metadatajob.cpp
+++ b/src/libs/installer/metadatajob.cpp
@@ -732,6 +732,7 @@ bool MetadataJob::fetchMetaDataPackages()
         setProcessedAmount(0);
         DownloadFileTask *const metadataTask = new DownloadFileTask(tempPackages);
         metadataTask->setProxyFactory(m_core->proxyFactory());
+        metadataTask->setSlbToken(m_core->value(QLatin1String("sessionToken")).toUtf8());
         m_metadataTask.setFuture(QtConcurrent::run(&DownloadFileTask::doTask, metadataTask));
         setInfoMessage(tr("Retrieving meta information from remote repository..."));
         return true;

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -2944,6 +2944,7 @@ PackagesList PackageManagerCorePrivate::remotePackages()
     m_updateFinder->setAutoDelete(false);
     m_updateFinder->setPackageSources(m_packageSources + m_compressedPackageSources);
     m_updateFinder->setLocalPackageHub(m_localPackageHub);
+    m_updateFinder->setSlbToken(m_core->value(QLatin1String("sessionToken")).toUtf8());
     m_updateFinder->run();
 
     if (m_updateFinder->updates().isEmpty()) {

--- a/src/libs/kdtools/updatefinder.cpp
+++ b/src/libs/kdtools/updatefinder.cpp
@@ -77,6 +77,7 @@ UpdateFinder::UpdateFinder()
     , m_downloadsToComplete(0)
     , m_updatesXmlTasks(0)
     , m_updatesXmlTasksToComplete(0)
+    , m_slbToken(QByteArray())
 {
 }
 
@@ -110,6 +111,11 @@ void UpdateFinder::setLocalPackageHub(std::weak_ptr<LocalPackageHub> hub)
 void UpdateFinder::setPackageSources(const QSet<PackageSource> &sources)
 {
     m_packageSources = sources;
+}
+
+void UpdateFinder::setSlbToken(const QByteArray &newSlbToken)
+{
+    m_slbToken = newSlbToken;
 }
 
 /*!
@@ -296,6 +302,7 @@ bool UpdateFinder::downloadUpdateXMLFiles()
             if (!downloader)
                 break;
 
+            downloader->setSlbToken(m_slbToken);
             downloader->setUrl(url);
             downloader->setAutoRemoveDownloadedFile(true);
             connect(downloader, SIGNAL(downloadCanceled()), this, SLOT(slotDownloadDone()));

--- a/src/libs/kdtools/updatefinder.h
+++ b/src/libs/kdtools/updatefinder.h
@@ -102,6 +102,7 @@ public:
 
     void setLocalPackageHub(std::weak_ptr<LocalPackageHub> hub);
     void setPackageSources(const QSet<QInstaller::PackageSource> &sources);
+    void setSlbToken(const QByteArray &newSlbToken);
 
 private:
     void doRun() override;
@@ -137,6 +138,7 @@ private:
     int m_updatesXmlTasks;
     int m_updatesXmlTasksToComplete;
     QList<ParseXmlFilesTask*> m_xmlFileTasks;
+    QByteArray m_slbToken;
 };
 
 } // namespace KDUpdater


### PR DESCRIPTION
### Related:
1.  https://github.com/barcoopensource/di-qt-installer-framework/pull/14