### PR TITLE
feat(MI0698-3066): add custom operation not reverted when update

### DIFF
--- a/src/libs/installer/executeundoonlyuninstalloperation.cpp
+++ b/src/libs/installer/executeundoonlyuninstalloperation.cpp
@@ -1,0 +1,11 @@
+// executeundoonlyuninstalloperation.cpp
+#include "executeundoonlyuninstalloperation.h"
+
+using namespace QInstaller;
+
+ExecuteUndoOnlyUninstallOperation::ExecuteUndoOnlyUninstallOperation(PackageManagerCore *core)
+    : ElevatedExecuteOperation(core)
+{
+    setName(QLatin1String("ExecuteUndoOnlyUninstall"));
+    setValue(QLatin1String("keep-when-update"), true);
+}

--- a/src/libs/installer/executeundoonlyuninstalloperation.h
+++ b/src/libs/installer/executeundoonlyuninstalloperation.h
@@ -1,0 +1,19 @@
+// executeundoonlyuninstalloperation.h
+#ifndef EXECUTEUNDOONLYUNINSTALLOPERATION_H
+#define EXECUTEUNDOONLYUNINSTALLOPERATION_H
+
+#include "elevatedexecuteoperation.h"
+
+namespace QInstaller {
+
+class INSTALLER_EXPORT ExecuteUndoOnlyUninstallOperation : public ElevatedExecuteOperation
+{
+    Q_OBJECT
+
+public:
+    explicit ExecuteUndoOnlyUninstallOperation(PackageManagerCore *core);
+};
+
+}
+
+#endif

--- a/src/libs/installer/init.cpp
+++ b/src/libs/installer/init.cpp
@@ -37,6 +37,7 @@
 #include "selfrestartoperation.h"
 #include "installiconsoperation.h"
 #include "elevatedexecuteoperation.h"
+#include "executeundoonlyuninstalloperation.h"
 #include "fakestopprocessforupdateoperation.h"
 #include "createlinkoperation.h"
 #include "simplemovefileoperation.h"
@@ -92,6 +93,7 @@ void QInstaller::init()
     factory.registerUpdateOperation<SelfRestartOperation>(QLatin1String("SelfRestart"));
     factory.registerUpdateOperation<InstallIconsOperation>(QLatin1String("InstallIcons"));
     factory.registerUpdateOperation<ElevatedExecuteOperation>(QLatin1String("Execute"));
+    factory.registerUpdateOperation<ExecuteUndoOnlyUninstallOperation>(QLatin1String("ExecuteUndoOnlyUninstall"));
     factory.registerUpdateOperation<FakeStopProcessForUpdateOperation>(QLatin1String("FakeStopProcessForUpdate"));
     factory.registerUpdateOperation<CreateLinkOperation>(QLatin1String("CreateLink"));
     factory.registerUpdateOperation<SimpleMoveFileOperation>(QLatin1String("SimpleMoveFile"));

--- a/src/libs/installer/installer.pro
+++ b/src/libs/installer/installer.pro
@@ -88,6 +88,7 @@ HEADERS += packagemanagercore.h \
     init.h \
     adminauthorization.h \
     elevatedexecuteoperation.h \
+    executeundoonlyuninstalloperation.h\
     fakestopprocessforupdateoperation.h \
     progresscoordinator.h \
     minimumprogressoperation.h \
@@ -196,6 +197,7 @@ SOURCES += packagemanagercore.cpp \
     downloadarchivesjob.cpp \
     init.cpp \
     elevatedexecuteoperation.cpp \
+    executeundoonlyuninstalloperation.cpp\
     fakestopprocessforupdateoperation.cpp \
     progresscoordinator.cpp \
     minimumprogressoperation.cpp \

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -2066,6 +2066,12 @@ bool PackageManagerCorePrivate::runPackageUpdater()
                 componentsByName.insert(name, component);
 
             if (isUpdater()) {
+                //Customized operation with 'keep-when-update' value won't be reverted when updating
+                if (operation->value(QLatin1String("keep-when-update")).toBool()) {
+                    nonRevertedOperations.append(operation);
+                    continue;
+                }
+
                 // We found the component, the component is not scheduled for update, the dependency solver
                 // did not add the component as install dependency and there is no replacement, keep it.
                 if ((component && !component->updateRequested() && !componentsToInstall.contains(component)


### PR DESCRIPTION
As supportive operation for MXRV upgrade
### Reference:
https://doc.qt.io/qtinstallerframework/scripting.html#registering-custom-operations