### PR TITLE
fix(MI0698-3125): add virtual component list for cli remove

### DIFF
--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -1546,6 +1546,11 @@ bool PackageManagerCore::fetchLocalPackagesTree()
     std::function<void(QList<LocalPackage> *, bool)> loadLocalPackages;
     loadLocalPackages = [&](QList<LocalPackage> *treeNamePackages, bool firstRun) {
         foreach (auto &package, (firstRun ? installedPackages.values() : *treeNamePackages)) {
+            if (package.virtualComp && package.autoDependencies.isEmpty()) {
+                if (!d->m_localVirtualComponents.contains(package.name))
+                    d->m_localVirtualComponents.append(package.name);
+            }
+
             if (firstRun && !package.treeName.first.isEmpty()) {
                 // Package has a tree name, leave for later
                 treeNamePackages->append(package);


### PR DESCRIPTION
### Overview:
When 'remove' with cli, '_uninstallComponentsSilently_' uses '_fetchLocalPackagesTree_' instead of '_fetchAllPackages_', which lacks virtual components list for '_UninstallerCalculator_' 's '_appendVirtualComponentsToUninstall_' to calculate whether installed virtual components are still needed, that's why all virtual dependency components remain.