### PR TITLE
fix(MI0304-409): not ask for proxy credential in cli mode

### DIFF
--- a/src/libs/installer/downloadfiletask.cpp
+++ b/src/libs/installer/downloadfiletask.cpp
@@ -285,7 +285,7 @@ void Downloader::errorOccurred(QNetworkReply::NetworkError error)
         if (data.taskItem.source().contains(QLatin1String("Updates.xml"), Qt::CaseInsensitive)) {
         //Do not throw error if Updates.xml not found. The repository might be removed
         //with RepositoryUpdate in Updates.xml later.
-            if (error == QNetworkReply::ContentNotFoundError || error == QNetworkReply::ContentGoneError) {
+            if (error == QNetworkReply::ContentNotFoundError || error == QNetworkReply::ContentGoneError || error == QNetworkReply::UnknownContentError) {
                 qCWarning(QInstaller::lcServer) << QString::fromLatin1("Network error while downloading '%1': %2.").arg(data.taskItem.source(), reply->errorString());
             } else {
                 m_futureInterface->reportException(

--- a/src/libs/installer/downloadfiletask.cpp
+++ b/src/libs/installer/downloadfiletask.cpp
@@ -282,12 +282,15 @@ void Downloader::errorOccurred(QNetworkReply::NetworkError error)
 
     if (reply) {
         const Data &data = *m_downloads[reply];
+        if (data.taskItem.source().contains(QLatin1String("Updates.xml"), Qt::CaseInsensitive)) {
         //Do not throw error if Updates.xml not found. The repository might be removed
         //with RepositoryUpdate in Updates.xml later.
-        //: %2 is a sentence describing the error
-        if (data.taskItem.source().contains(QLatin1String("Updates.xml"), Qt::CaseInsensitive)) {
-            qCWarning(QInstaller::lcServer) << QString::fromLatin1("Network error while downloading '%1': %2.").arg(
-                   data.taskItem.source(), reply->errorString());
+            if (error == QNetworkReply::ContentNotFoundError || error == QNetworkReply::ContentGoneError) {
+                qCWarning(QInstaller::lcServer) << QString::fromLatin1("Network error while downloading '%1': %2.").arg(data.taskItem.source(), reply->errorString());
+            } else {
+                m_futureInterface->reportException(
+                    TaskException(tr("Network error while downloading '%1': %2.").arg(data.taskItem.source(), reply->errorString())));
+            }
         } else if (data.taskItem.source().contains(QLatin1String("_meta"), Qt::CaseInsensitive)) {
             QString errorString = tr("Network error while downloading '%1': %2.").arg(data.taskItem.source(), reply->errorString());
             errorString.append(ProductKeyCheck::instance()->additionalMetaDownloadWarning());

--- a/src/libs/installer/metadatajob.cpp
+++ b/src/libs/installer/metadatajob.cpp
@@ -507,7 +507,11 @@ void MetadataJob::xmlTaskFinished()
             const QNetworkProxy proxy = e.proxy();
             if (m_core->isCommandLineInstance()) {
                 qCDebug(QInstaller::lcInstallerInstallLog).noquote() << QString::fromLatin1("The proxy %1:%2 requires a username and password").arg(proxy.hostName(), proxy.port());
-                askForCredentials(&username, &password, QLatin1String("Username: "), QLatin1String("Password: "));
+                // askForCredentials(&username, &password, QLatin1String("Username: "), QLatin1String("Password: "));
+                //without console output, not asking for credentials, as that would cause infinite loop - MI0304-409
+                reset();
+                emitFinishedWithError(QInstaller::DownloadError, tr("Missing or wrong proxy credentials."));
+                return;
             } else {
                 ProxyCredentialsDialog proxyCredentials(proxy);
                 if (proxyCredentials.exec() == QDialog::Accepted) {
@@ -533,7 +537,10 @@ void MetadataJob::xmlTaskFinished()
             if (m_core->isCommandLineInstance()) {
                 qCDebug(QInstaller::lcInstallerInstallLog) << "Server Requires Authentication";
                 qCDebug(QInstaller::lcInstallerInstallLog) << "You need to supply a username and password to access this site.";
-                askForCredentials(&username, &password, QLatin1String("Username: "), QLatin1String("Password: "));
+                // askForCredentials(&username, &password, QLatin1String("Username: "), QLatin1String("Password: "));
+                reset();
+                emitFinishedWithError(QInstaller::DownloadError, tr("Missing or wrong server credentials."));
+                return;
             } else {
                 ServerAuthenticationDialog dlg(e.message(), e.taskItem());
                 if (dlg.exec() == QDialog::Accepted) {

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -3029,11 +3029,15 @@ bool PackageManagerCorePrivate::fetchMetaInformationFromRepositories(DownloadTyp
     }
 
     if (m_metadataJob.error() != Job::NoError) {
+        bool isCompressedRepo = (type == DownloadType::CompressedPackage);
         switch (m_metadataJob.error()) {
             case QInstaller::UserIgnoreError:
                 break;  // we can simply ignore this error, the user knows about it
             default:
-                // setStatus(PackageManagerCore::Failure, m_metadataJob.errorString());   //previous false compressed repo will block next right compressed one
+                if(isCompressedRepo){
+                    return m_repoFetched;   //previous false compressed repo will block next right compressed one
+                }
+                setStatus(PackageManagerCore::Failure, m_metadataJob.errorString());   
                 return m_repoFetched;
         }
     }

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -3035,6 +3035,7 @@ bool PackageManagerCorePrivate::fetchMetaInformationFromRepositories(DownloadTyp
                 break;  // we can simply ignore this error, the user knows about it
             default:
                 if(isCompressedRepo){
+                    qCWarning(QInstaller::lcInstallerInstallLog) << m_metadataJob.errorString();
                     return m_repoFetched;   //previous false compressed repo will block next right compressed one
                 }
                 setStatus(PackageManagerCore::Failure, m_metadataJob.errorString());   

--- a/src/sdk/tabcontroller.cpp
+++ b/src/sdk/tabcontroller.cpp
@@ -86,16 +86,6 @@ TabController::TabController(QObject *parent)
 
 TabController::~TabController()
 {
-    //try writing config file before writeMaintenanceTool 250324
-    bool gainedAdminRights = false;
-    if (!d->m_core->directoryWritable(d->m_core->value(scTargetDir))) {
-        d->m_core->gainAdminRights();
-        gainedAdminRights = true;
-    }
-    d->m_core->writeMaintenanceConfigFiles();
-    if (gainedAdminRights)
-        d->m_core->dropAdminRights();
-
     d->m_core->writeMaintenanceTool();
     delete d;
 }


### PR DESCRIPTION
### Local Test:
#### Wrong proxy address or portId:
<img width="951" height="62" alt="image" src="https://github.com/user-attachments/assets/7fed1704-9013-4e9f-93de-3df1f23e1798" />

#### Wrong proxy credentials:
<img width="416" height="42" alt="image" src="https://github.com/user-attachments/assets/4e3a3804-4e90-49f5-9a53-27af549bf9db" />

### Related previous pr:
1. https://github.com/barcoopensource/di-qt-installer-framework/pull/23
2. https://github.com/barcoopensource/di-qt-installer-framework/pull/6