### PR TITLE
chore: hide installed version column when in package manager mode

### DIFF
--- a/src/libs/installer/componentselectionpage_p.cpp
+++ b/src/libs/installer/componentselectionpage_p.cpp
@@ -301,6 +301,11 @@ void ComponentSelectionPagePrivate::updateTreeView()
     if (!installActionColumnVisible)
         m_treeView->hideColumn(ComponentModelHelper::ActionColumn);
 
+    if (m_core->isPackageManager())
+    {
+        m_treeView->hideColumn(ComponentModelHelper::InstalledVersionColumn);
+    }
+
     m_treeView->header()->setSectionResizeMode(
                 ComponentModelHelper::NameColumn, QHeaderView::ResizeToContents);
     if (m_core->isInstaller()) {

--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -5164,15 +5164,15 @@ ComponentModel *PackageManagerCore::componentModel(PackageManagerCore *core, con
 
     model->setObjectName(objectName);
     model->setHeaderData(ComponentModelHelper::NameColumn, Qt::Horizontal,
-        ComponentModel::tr("Component Name"));
+        ComponentModel::tr("Component name"));
     model->setHeaderData(ComponentModelHelper::ActionColumn, Qt::Horizontal,
         ComponentModel::tr("Action"));
     model->setHeaderData(ComponentModelHelper::InstalledVersionColumn, Qt::Horizontal,
-        ComponentModel::tr("Installed Version"));
+        ComponentModel::tr("Old version"));
     model->setHeaderData(ComponentModelHelper::NewVersionColumn, Qt::Horizontal,
-        ComponentModel::tr("New Version"));
+        ComponentModel::tr("New version"));
     model->setHeaderData(ComponentModelHelper::ReleaseDateColumn, Qt::Horizontal,
-        ComponentModel::tr("Release Date"));
+        ComponentModel::tr("Release date"));
     model->setHeaderData(ComponentModelHelper::UncompressedSizeColumn, Qt::Horizontal,
         ComponentModel::tr("Size"));
 


### PR DESCRIPTION
## package manager mode
<img width="1282" height="735" alt="package_manager" src="https://github.com/user-attachments/assets/43238867-82f1-42fa-b2e3-ad930746623b" />

## update mode
<img width="1240" height="688" alt="Update_mode" src="https://github.com/user-attachments/assets/faba12fe-2180-40dc-b97d-5cc824c92f20" />
