### PR TITLE
fix(MI0698-3470): clear treeview and exclude stale bundle cache when reloading

### DIFF
--- a/src/libs/installer/metadatajob.cpp
+++ b/src/libs/installer/metadatajob.cpp
@@ -888,6 +888,24 @@ void MetadataJob::resetCompressedFetch()
     setError(Job::NoError);
     setErrorString(QString());
 
+    // Remove previously staged compressed repo metadata
+    for (auto it = m_fetchedMetadata.begin(); it != m_fetchedMetadata.end(); ) {
+        if (it.value() && it.value()->repository().isCompressed()) {
+            delete it.value();
+            it = m_fetchedMetadata.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    // Deactivate items committed to the persistent cache, so that it won't be loaded in metadata()
+    for (auto *item : m_metaFromCache.items()) {
+        if (item && item->repository().isCompressed()) {
+            item->setRepository(Repository());
+            item->setAvailableFromDefaultRepository(false);
+        }
+    }
+
     try {
         foreach (QFutureWatcher<void> *const watcher, m_unzipTasks.keys()) {
             watcher->cancel();

--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -1688,6 +1688,7 @@ PackagesList PackageManagerCore::remotePackages()
 */
 bool PackageManagerCore::fetchCompressedPackagesTree()
 {
+    emit startAllComponentsReset();
     const LocalPackagesMap installedPackages = d->localInstalledPackages();
     if (!isInstaller() && status() == Failure)
         return false;
@@ -2091,7 +2092,7 @@ bool PackageManagerCore::addQBspRepositories(const QStringList &repositories)
         set.insert(repository);
     }
     if (set.count() > 0) {
-        settings().addTemporaryRepositories(set, false);
+        settings().setTemporaryRepositories(set, true);
         return true;
     }
     return false;

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -3118,6 +3118,8 @@ void FinishedPage::entering()
     if (m_commitButton) {
         disconnect(m_commitButton, &QAbstractButton::clicked, this, &FinishedPage::handleFinishClicked);
         connect(m_commitButton, &QAbstractButton::clicked, this, &FinishedPage::handleFinishClicked);
+        if (QPushButton *const b = qobject_cast<QPushButton *>(m_commitButton))
+            b->setDefault(true);
     }
 
     QString finishedText;


### PR DESCRIPTION
### Background Info:
1. connect(this, &PackageManagerCore::**startAllComponentsReset**, [&] { d->m_defaultModel->reset(); });
'startAllComponentsReset' signal will reset component model and then treeview in component page
2. It's default behavior of QIF to preserve and reload previously loaded bundle from cache, has to be cancelled in compressed bundle loading