### PR TITLE
fix: license management always show horizontal scroll bar

### DIFF
--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -2469,6 +2469,9 @@ LicenseAgreementPage::LicenseAgreementPage(PackageManagerCore *core)
     m_textBrowser->setReadOnly(true);
     m_textBrowser->setOpenLinks(false);
     m_textBrowser->setOpenExternalLinks(true);
+    m_textBrowser->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_textBrowser->setLineWrapMode(QTextEdit::WidgetWidth);
+    m_textBrowser->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     m_textBrowser->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     m_textBrowser->setObjectName(QLatin1String("LicenseTextBrowser"));
     connect(m_textBrowser, &QTextBrowser::anchorClicked, this, &LicenseAgreementPage::openLicenseUrl);

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -2470,8 +2470,6 @@ LicenseAgreementPage::LicenseAgreementPage(PackageManagerCore *core)
     m_textBrowser->setOpenLinks(false);
     m_textBrowser->setOpenExternalLinks(true);
     m_textBrowser->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    m_textBrowser->setLineWrapMode(QTextEdit::WidgetWidth);
-    m_textBrowser->setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     m_textBrowser->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     m_textBrowser->setObjectName(QLatin1String("LicenseTextBrowser"));
     connect(m_textBrowser, &QTextBrowser::anchorClicked, this, &LicenseAgreementPage::openLicenseUrl);


### PR DESCRIPTION
<img width="1246" height="664" alt="image" src="https://github.com/user-attachments/assets/d2b57f08-d4d2-4771-97b2-e713659d5542" />
