### PR TITLE
fix: pass proper para to findMagicCookie function

### DIFF
--- a/src/libs/installer/binarycontent.cpp
+++ b/src/libs/installer/binarycontent.cpp
@@ -95,6 +95,9 @@ qint64 BinaryContent::findMagicCookie(QFile *in, quint64 magicCookie)
         --searched;
     }
 
+    throw Error(QCoreApplication::translate("QInstaller", "No marker found, stopped after %1.")
+    .arg(humanReadableSize(maxSearch)));
+
     return -1; // never reached
 }
 

--- a/src/sdk/sdkapp.h
+++ b/src/sdk/sdkapp.h
@@ -569,7 +569,7 @@ public:
                         f.open(QIODevice::ReadOnly);
                         if (f.fileName().endsWith(QLatin1String("installer.dat")))
                              continue;
-                        QInstaller::BinaryContent::findMagicCookie(&f, magicMarker);
+                        QInstaller::BinaryContent::findMagicCookie(&f, QInstaller::BinaryContent::MagicCookieDat);
                         datFileName = f.fileName();
                         break;
                     } catch (const QInstaller::Error &error) {


### PR DESCRIPTION
### Related:
1. https://github.com/barcoopensource/di-qt-installer-framework/pull/20
### Background:
It wrongly passes 'magicMarker' instead of 'MagicCookieDat' to it, reports unwanted error with .dat file verification, restores previously deleted error