### PR TITLE
fix(MI0698-3775): force full progress percentage in uninstaller mode

### DIFF
--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -2356,6 +2356,11 @@ bool PackageManagerCorePrivate::runUninstaller()
         }
 #endif
 
+        //show a full progress bar when completed
+        const int progress = ProgressCoordinator::instance()->progressInPercentage();
+        if (progress < 100)
+            ProgressCoordinator::instance()->addManualPercentagePoints(100 - progress);
+
         unregisterMaintenanceTool();
         m_needToWriteMaintenanceTool = false;
         setStatus(PackageManagerCore::Success);
@@ -2369,11 +2374,6 @@ bool PackageManagerCorePrivate::runUninstaller()
         if(m_error.isEmpty())
             m_error = err.message(); 
     }
-
-    //show a full progress bar when completed
-    const int progress = ProgressCoordinator::instance()->progressInPercentage();
-    if (progress < 100)
-        ProgressCoordinator::instance()->addManualPercentagePoints(100 - progress);
 
     const bool success = (m_core->status() == PackageManagerCore::Success);
     if (adminRightsGained)

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -2370,6 +2370,11 @@ bool PackageManagerCorePrivate::runUninstaller()
             m_error = err.message(); 
     }
 
+    //show a full progress bar when completed
+    const int progress = ProgressCoordinator::instance()->progressInPercentage();
+    if (progress < 100)
+        ProgressCoordinator::instance()->addManualPercentagePoints(100 - progress);
+
     const bool success = (m_core->status() == PackageManagerCore::Success);
     if (adminRightsGained)
         m_core->dropAdminRights();


### PR DESCRIPTION
As it's already doing in installer/updater mode:
https://github.com/barcoopensource/di-qt-installer-framework/blob/develop/src/libs/installer/packagemanagercore_p.cpp#L2084