### PR TITLE
fix: not move error label in installer

### DIFF
--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -2330,7 +2330,9 @@ void IntroductionPage::updateErrorLabelPosition()
     }
 
     m_errorLabel->adjustSize();
-    m_errorLabel->move(kErrorLabelMargin, height() - kErrorLabelMargin - m_errorLabel->height());
+    PackageManagerCore *core = packageManagerCore();
+    if (!core->isInstaller())
+        m_errorLabel->move(kErrorLabelMargin, height() - kErrorLabelMargin - m_errorLabel->height());
 }
 
 


### PR DESCRIPTION
<img width="1188" height="701" alt="image" src="https://github.com/user-attachments/assets/14576065-2a79-4a03-a99f-175a90648e51" />
